### PR TITLE
better launch power sensibility

### DIFF
--- a/3d/src/index.ts
+++ b/3d/src/index.ts
@@ -146,7 +146,7 @@ function animate(time: number) {
       new THREE.Vector3(0, 120, 0),
       -arrow.getVerticalAngle() + Math.PI / 2,
       arrow.getHorizontalAngle(),
-      60 + arrow.getPower() * 20,
+      40 + arrow.getPower() * 40,
     );
 
     currentThrow += 1;


### PR DESCRIPTION
Use a power between 40 and 80.

Why the first 40 ? Because it's enough to be able to see the rondelle hitting lamentably the floor.

Why multiply the arrow power with another 40 ? Because the arrow power is between 0 and 1 : 
* around 60 (yellow arrow) seems to be the good power to be able to embrace the bottle with the rondelle
* around 80 seems enough to try to break the window (but it's a so-called "double-vitrage very resistant" so the little and soft rondelle has a very tiny probability to break it)